### PR TITLE
docs/ Add commit convention to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # DD2480_CI
 Continuous Integration Assignment in the KTH course DD2480.
+
+## Commit convention
+All commits should be performed on the appropriate issue branch
+
+Prefixes: ```feat/, fix/, doc/, refactor/, test/```
+
+New since last project: use ```test/``` instead of ```feat/``` when adding tests, based on feedback from TA.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Continuous Integration Assignment in the KTH course DD2480.
 ## Commit convention
 All commits should be performed on the appropriate issue branch
 
-Prefixes: ```feat/, fix/, doc/, refactor/, test/```
+Prefixes: ```feat/, fix/, docs/, refactor/, test/```
 
-New since last project: use ```test/``` instead of ```feat/``` when adding tests, based on feedback from TA.
+New since last project: use ```test/``` instead of ```feat/``` when adding tests, based on feedback from TA. Additionally, use ```docs/``` instead of ```doc/``` (notice the s).


### PR DESCRIPTION
Includes new prefix recommended by TA, test/.

closes #4 