### PR TITLE
feat/ implemented handler to receive and deserialize json payload

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -3,3 +3,7 @@ build:
 
 run:
 	java -jar target/ci-0.0.1-SNAPSHOT.jar
+
+build-run:
+	mvn clean package
+	java -jar target/ci-0.0.1-SNAPSHOT.jar

--- a/ci/pom.xml
+++ b/ci/pom.xml
@@ -27,6 +27,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+        </dependency>
 		
 		<dependency>
 			<groupId>org.springdoc</groupId>

--- a/ci/src/main/java/group17/ci/PullRequestPayload.java
+++ b/ci/src/main/java/group17/ci/PullRequestPayload.java
@@ -1,0 +1,55 @@
+package group17.ci;
+
+/**
+ * This class contains the Payload structure for GitHub webhook pull request events. It is used to serialize the json fields that are needed. 
+ * 
+ * @author Group 17
+ * @version 1.0.0
+ */
+public class PullRequestPayload {
+    public String action;
+    public String number;
+    public PullRequest pull_request;
+    
+}
+
+/**
+ * This class contains all information regarding the pull request and is neted inside PullRequestPayload
+ *
+ * */
+class PullRequest {
+    public String html_url;
+    public String title;
+    public String body;
+    public User user;
+    public String created_at;
+    public String updated_at;
+    public Head head;
+    public Repo repo;
+}
+
+/**
+ * This class contains info about HEAD and is nested inside PullRequest
+ */
+class Head {
+    public String label; // login:branch e.g. asirago:issue/58
+    public String ref; // branch e.g. issue/58
+    public String sha; // commit hash e.g. 5dc964a2730e153208e09ac242bcd40c919374d2
+}
+
+/**
+ * This class contains repository info and is nested inside PullRequest
+ */
+class Repo {
+    public String ssh_url; // ssh url e.g. git@github.com:Lussebullen/DD2480_DECIDE.git
+    public String clone_url; // clone url e.g. https://github.com/asirago/GitHubActionsTest.git
+
+}
+
+/**
+ * This class contains User information and is nested inside PullRequest
+ */
+class User {
+    public String login;
+    public String html_url;
+}

--- a/ci/src/main/java/group17/ci/Router.java
+++ b/ci/src/main/java/group17/ci/Router.java
@@ -2,7 +2,12 @@ package group17.ci;
  
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
  
 @RestController
 public class Router {
@@ -25,5 +30,22 @@ public class Router {
         System.out.println("Hello someone just visited this link: probably github sending something");
 
         return "Commit ID: " + commitId;
+    }
+
+    /**
+     * Handles POST request to /github-webhook and works as a receiver of GitHub pull request webhooks events
+     *
+     * @param payload The data representing the pull request payloada GitHub sent us via webhooks.
+     */
+    @PostMapping("/github-webhook")
+    public void githubReceiver(@RequestBody PullRequestPayload payload) {
+
+        try {
+            String prettyJson = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(payload);
+            System.out.println(prettyJson); // Print the pretty printed JSON
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
     }
 }


### PR DESCRIPTION
- Added PullRequestPayload.java to mimic the structure of the json payload from the Github webhook pull request event
- @PostMappin("/github-webhook) deserializes the json automatically with `@RequestBody PullRequestPayload payload`.
- jackson.databind.ObjectMapper, a third party dependency for parsing json was also added to the `pom.xml` file.
- Added build-run command in Makefile for building and running the java sprint boot application

closes #14