### PR TITLE
refactor/ Improve compileTestLog.sh as suggested by #29

### DIFF
--- a/ci/compileTestLog.sh
+++ b/ci/compileTestLog.sh
@@ -2,51 +2,45 @@
 
 hash=$1                                    
 path_logs="../../src/main/resources/logs/" 
-path_compile_logs="$path_logs/compilelogs" 
-path_test_logs="$path_logs/testlogs"       
+logfile="$path_logs/$hash.log"
+original_directory=$PWD
 
-
-## Spawn subshell
-(
-git clone -b assessment https://github.com/Lussebullen/DD2480_CI.git cirepo
 ## Consider providing as argument?
+git clone -b assessment https://github.com/Lussebullen/DD2480_CI.git cirepo
 cd cirepo/decide
 
 ## Create log directories if non-existing
 mkdir -p $path_logs 
-#mkdir -p $path_compile_logs
-#mkdir -p $path_test_logs
 
 ## Write date, time, commit id and compile results to file
-printf "Date: " > "$path_logs/$hash.log"
-date +%Y/%m/%d >> "$path_logs/$hash.log"
-printf "Time: " >> "$path_logs/$hash.log"
-date +%H:%M:%S >> "$path_logs/$hash.log"
-printf "Commit ID: $hash\n" >> "$path_logs/$hash.log"
-printf "Compilation Logs\n" >> "$path_logs/$hash.log"
-mvn compile >> "$path_logs/$hash.log"
+printf "Date: " > $logfile
+date +%Y/%m/%d >> $logfile
+printf "Time: " >> $logfile
+date +%H:%M:%S >> $logfile
+printf "Commit ID: $hash\n" >> $logfile
+printf "Compilation Logs\n" >> $logfile
+mvn compile >> $logfile
 
 
-if grep -q failure "$path_logs/$hash.log" 
+if grep -q FAILURE $logfile 
 then
     exit 1
 fi
 
 
 ## Write date, time, commit id and test results to file
-printf "Test Logs\n" >> "$path_logs/$hash.log"
-mvn test >> "$path_logs/$hash.log"
+printf "Test Logs\n" >> $logfile
+mvn test >> $logfile
 
-if grep -q failure "$path_logs/$hash.log" 
+if grep -q FAILURE $logfile 
 then
     exit 1
 fi
 
  ## HTML format by replacing newlines with break tags
  ## Kudos to https://stackoverflow.com/questions/1251999/how-can-i-replace-each-newline-n-with-a-space-using-sed
- sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' "$path_logs/$hash.log"
+ sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
 
-)
-
+cd $original_directory
 rm -rf cirepo
 


### PR DESCRIPTION
This commit:
   * Adds variable to log file path thus removing path repetition.
   * Replaces subshell by storing original directory location and `cd`
      back to it before finishing script.
   * Remove redundant variables and commands that are not planned on
      being used anymore.

Reasons behind first two decision can be found in #29. Third change is simply to remove redundancy.  

closes #29