### PR TITLE
fix/ Fix unfriendly log format on web when build fails

### DIFF
--- a/ci/compileTestLog.sh
+++ b/ci/compileTestLog.sh
@@ -24,6 +24,7 @@ mvn compile >> $logfile
 
 if grep -q FAILURE $logfile 
 then
+    sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
     exit 1
 fi
 
@@ -34,6 +35,7 @@ mvn test >> $logfile
 
 if grep -q FAILURE $logfile 
 then
+    sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
     exit 1
 fi
 


### PR DESCRIPTION
Add proper formatting when build fails to display it friendly on the web endpoint. For further info see #33.

closes #33