### PR TITLE
fix/ Remove cloned branch on failing builds

### DIFF
--- a/ci/compileTestLog.sh
+++ b/ci/compileTestLog.sh
@@ -25,6 +25,8 @@ mvn compile >> $logfile
 if grep -q FAILURE $logfile 
 then
     sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
+    cd $original_directory
+    rm -rf cirepo
     exit 1
 fi
 
@@ -36,6 +38,8 @@ mvn test >> $logfile
 if grep -q FAILURE $logfile 
 then
     sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
+    cd $original_directory
+    rm -rf cirepo
     exit 1
 fi
 


### PR DESCRIPTION
compileTestRun.sh now removes the cloned branch when a build fails, thus making it possible to clone the updated branch on the next push. Previously the old repo remained if the build failed, preventing a new clone when the script executes next time. For details, see #35.

fixes #35