### PR TITLE
refactor/ Remove hardcoded URL to use HTTP payload instead

### DIFF
--- a/ci/compileTestLog.sh
+++ b/ci/compileTestLog.sh
@@ -1,52 +1,70 @@
 #!/bin/sh
 
-hash=$1                                    
-path_logs="../../src/main/resources/logs/" 
-logfile="$path_logs/$hash.log"
-original_directory=$PWD
+commit_id=$1                                    
+clone_url=$2
+branch_name=$3
 
-## Consider providing as argument?
-git clone -b assessment https://github.com/Lussebullen/DD2480_CI.git cirepo
-cd cirepo/decide
-
+path_logs="src/main/resources/logs/"
 ## Create log directories if non-existing
 mkdir -p $path_logs 
-
-## Write date, time, commit id and compile results to file
-printf "Date: " > $logfile
-date +%Y/%m/%d >> $logfile
-printf "Time: " >> $logfile
-date +%H:%M:%S >> $logfile
-printf "Commit ID: $hash\n" >> $logfile
-printf "Compilation Logs\n" >> $logfile
-mvn compile >> $logfile
+logfile="$path_logs/$commit_id.log"
 
 
-if grep -q FAILURE $logfile 
+local_clone_name=cirepo
+rm -rf $local_clone_name
+git clone --quiet -b $branch_name $clone_url $local_clone_name 
+cloneExitCode=$?
+if [[ $cloneExitCode -eq 0 ]];
 then
-    sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
+    printf "Successfully cloned repo from URL: $clone_url. \n \
+            Switched to branch \"$branch_name.\"\n" > $logfile
+else
+    printf "Failed to clone repo from URL: $clone_url.\n" > $logfile
+    exit 1;
+fi
+
+original_directory=$PWD
+cd $local_clone_name/decide
+relative_path_logfile="../../$logfile"
+
+
+## Write date, time, commit id to file
+printf "Date: "                  >> $relative_path_logfile
+date   +%Y/%m/%d                 >> $relative_path_logfile
+printf "Time: "                  >> $relative_path_logfile
+date   +%H:%M:%S                 >> $relative_path_logfile
+printf "Commit ID: $commit_id\n" >> $relative_path_logfile
+
+## Compile project and write log to file
+printf "\nCompilation Logs\n"    >> $relative_path_logfile
+mvn    compile                   >> $relative_path_logfile
+
+
+if grep -q FAILURE $relative_path_logfile 
+then
+    sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $relative_path_logfile
     cd $original_directory
-    rm -rf cirepo
+    rm -rf $local_clone_name
     exit 1
 fi
 
 
 ## Write date, time, commit id and test results to file
-printf "Test Logs\n" >> $logfile
-mvn test >> $logfile
+printf "\nTest Logs\n" >> $relative_path_logfile
+mvn    test            >> $relative_path_logfile
 
-if grep -q FAILURE $logfile 
+if grep -q FAILURE $relative_path_logfile 
 then
-    sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
+    sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $relative_path_logfile
     cd $original_directory
-    rm -rf cirepo
+    rm -rf $local_clone_name
     exit 1
 fi
 
- ## HTML format by replacing newlines with break tags
- ## Kudos to https://stackoverflow.com/questions/1251999/how-can-i-replace-each-newline-n-with-a-space-using-sed
- sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $logfile
+## HTML format by replacing newlines with break tags
+## Kudos to https://stackoverflow.com/questions/1251999/how-can-i-replace-each-newline-n-with-a-space-using-sed
+sed -i -e ':a' -e 'N' -e '$!ba' -e 's/\n/<br>\n/g' $relative_path_logfile
 
 cd $original_directory
-rm -rf cirepo
+rm -rf $local_clone_name
 

--- a/ci/src/main/java/group17/ci/PushPayload.java
+++ b/ci/src/main/java/group17/ci/PushPayload.java
@@ -14,6 +14,7 @@ public class PushPayload {
     public String after;
     public HeadCommit head_commit;
     public Repo repository;
+    public String clone_url; // clone url e.g. https://github.com/asirago/GitHubActionsTest.git
     
 }
 

--- a/ci/src/main/java/group17/ci/Router.java
+++ b/ci/src/main/java/group17/ci/Router.java
@@ -85,10 +85,10 @@ public class Router {
      * 
      * return   CIBuildStatus.GOOD if no failures occured, BAD variant otherwise.
      */
-    private CIBuildStatus compileAndTestBranch(String commitHash) 
+    private CIBuildStatus compileAndTestBranch(String commitHash, String cloneURL, String branchName) 
     {
         int exitStatus = 1;
-        String[] command = { "./compileTestLog.sh", commitHash };
+        String[] command = { "./compileTestLog.sh", commitHash , cloneURL, branchName};
         try {
             Process process = Runtime.getRuntime().exec(command);
             exitStatus = process.waitFor();
@@ -115,7 +115,7 @@ public class Router {
         sendCommitStatus(payload, new CommitStatus("pending", "building and testing...", "ciserver/build-test", "https://dd2480-ciserver.asirago.xyz/logs/" + payload.head_commit.id));
 
         // Compile and test the project
-        CIBuildStatus buildStatus = compileAndTestBranch(payload.head_commit.id);
+        CIBuildStatus buildStatus = compileAndTestBranch(payload.head_commit.id, payload.clone_url, payload.ref.substring("refs/heads/".length()));
 
         // Elapsed time
         int elapsedTime = (int) ((System.nanoTime() - startTime) / 1_000_000_000.0);


### PR DESCRIPTION
This commit:
* Removes hardcoded URL in compileTestLog.sh and instead clones repo
      that triggered webhook using HTTP payload inside webhook.
* Removes hardcoded branch switch to also use payload info.
* Minor refactor of compileTestLog.sh, i.e. switched order on some
      commands and variable names.
* Print info to log file if git repo was successfully cloned or not.

Decision to change from hardcoded URL to using payload was made to comply with the relevant assignment properties.
 
closes #39