### PR TITLE
fix/ Fixed nullpointer issue in webhook endpoint

### DIFF
--- a/ci/src/main/java/group17/ci/Router.java
+++ b/ci/src/main/java/group17/ci/Router.java
@@ -125,7 +125,7 @@ public class Router {
         sendCommitStatus(payload, new CommitStatus("pending", "building and testing...", "ciserver/build-test", "https://dd2480-ciserver.asirago.xyz/logs/" + payload.head_commit.id));
 
         // Compile and test the project
-        CIBuildStatus buildStatus = compileAndTestBranch(payload.head_commit.id, payload.clone_url, branchName);
+        CIBuildStatus buildStatus = compileAndTestBranch(payload.head_commit.id, payload.repository.clone_url, branchName);
 
         // Elapsed time
         int elapsedTime = (int) ((System.nanoTime() - startTime) / 1_000_000_000.0);


### PR DESCRIPTION
Fixed unnoticed json nesting of the clone_url to rectify null-pointer error.

Co-authored-by: Omar-AV <71982892+Omar-AV@users.noreply.github.com>

fixes #44 